### PR TITLE
adds new RingPop API method to retrieve full member object 

### DIFF
--- a/swim/labels.go
+++ b/swim/labels.go
@@ -18,7 +18,7 @@ var (
 	//    memberlist being sent over the wire 5 times a second.
 	// When all contiditions are met the Labels would add the following load
 	// (non-compressed) to the network:
-	//    (32+128)*5*1000*5*8 = ~32mbit/s
+	//    (32+128)*10*1000*5*8 = ~64mbit/s
 	DefaultLabelOptions = LabelOptions{
 		KeySize:   32,
 		ValueSize: 128,

--- a/swim/labels.go
+++ b/swim/labels.go
@@ -22,7 +22,7 @@ var (
 	DefaultLabelOptions = LabelOptions{
 		KeySize:   32,
 		ValueSize: 128,
-		Count:     5,
+		Count:     10,
 	}
 
 	// ErrLabelSizeExceeded indicates that an operation on labels would exceed

--- a/test/mocks/ringpop.go
+++ b/test/mocks/ringpop.go
@@ -186,6 +186,29 @@ func (_m *Ringpop) GetReachableMembers(predicates ...swim.MemberPredicate) ([]st
 	return r0, r1
 }
 
+// GetReachableMemberObjects provides a mock function with given fields: predicates
+func (_m *Ringpop) GetReachableMemberObjects(predicates ...swim.MemberPredicate) ([]swim.Member, error) {
+	ret := _m.Called(predicates)
+
+	var r0 []swim.Member
+	if rf, ok := ret.Get(0).(func(...swim.MemberPredicate) []swim.Member); ok {
+		r0 = rf(predicates...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]swim.Member)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(...swim.MemberPredicate) error); ok {
+		r1 = rf(predicates...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CountReachableMembers provides a mock function with given fields: predicates
 func (_m *Ringpop) CountReachableMembers(predicates ...swim.MemberPredicate) (int, error) {
 	ret := _m.Called(predicates)


### PR DESCRIPTION
The RingPop API returns the host/port of reachable members, but not their actual member object. We want the caller to access the Labels reported by the nodes as a means of surfacing any optional extra-metadata