### PR TITLE
Use global rand source

### DIFF
--- a/swim/heal_via_discover_provider.go
+++ b/swim/heal_via_discover_provider.go
@@ -46,8 +46,6 @@ type discoverProviderHealer struct {
 	started              chan struct{}
 
 	logger log.Logger
-
-	rand *rand.Rand
 }
 
 func newDiscoverProviderHealer(n *Node, baseProbability float64, period time.Duration) *discoverProviderHealer {
@@ -58,7 +56,6 @@ func newDiscoverProviderHealer(n *Node, baseProbability float64, period time.Dur
 		logger:           logging.Logger("healer").WithField("local", n.Address()),
 		started:          make(chan struct{}, 1),
 		quit:             make(chan struct{}),
-		rand:             rand.New(rand.NewSource(n.clock.Now().UnixNano())),
 	}
 }
 
@@ -82,7 +79,7 @@ func (h *discoverProviderHealer) Start() {
 			}
 
 			// attempt heal with the pro
-			if h.rand.Float64() < h.Probability() {
+			if rand.Float64() < h.Probability() {
 				h.Heal()
 			}
 		}

--- a/swim/join_delayer.go
+++ b/swim/join_delayer.go
@@ -35,8 +35,7 @@ const (
 	defaultMax     = 60 * time.Second
 )
 
-var delayerRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-var defaultRandomizer = delayerRand.Intn
+var defaultRandomizer = rand.Intn
 var defaultSleeper = time.Sleep
 var noDelay = time.Duration(0)
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -295,8 +295,8 @@ func TestShuffleStringsInPlace(t *testing.T) {
 	}
 
 	// expected probability of 1/1000 for every index so the expected number of
-	// collisions is 1. We add some slack and expect smaller or equal than 3.
-	assert.True(t, collisions <= 3, "expected that array is shuffled")
+	// collisions is 1. We add some slack and expect smaller or equal than 6.
+	assert.True(t, collisions <= 6, "expected that array is shuffled")
 
 	sort.Strings(strs)
 	sort.Strings(strs2)


### PR DESCRIPTION
## What was changed
Use global rand instead of local sources.
Relax constraint in unit test to make it less flaky.

## Why?
Rand sources are not thread-safe and need synchronization. Since this source was seeded by time and not reproducible anyway, there's no reason to use a local source.

## Checklist
2. How was this tested:
existing tests
